### PR TITLE
Add OSCA.multisample to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,5 @@ Suggests:
     OSCA.intro,
     OSCA.basic,
     OSCA.advanced,
-    OSCA.workflows
+    OSCA.workflows,
+    OSCA.multisample


### PR DESCRIPTION
Fixes:
```
Quitting from lines 47-52 (contents.Rmd)
Error in packageDescription("OSCA.multisample")$Description :
  $ operator is invalid for atomic vectors
Calls: local ... handle -> withCallingHandlers -> withVisible -> eval -> eval
In addition: Warning message:
In packageDescription("OSCA.multisample") :
  no package 'OSCA.multisample' was found

Execution halted
Error in Rscript_render(f, render_args, render_meta, add1, add2) :
  Failed to compile contents.Rmd
Calls: <Anonymous> -> render_new_session -> Rscript_render
```
when running
```
bookdown::render_book("index.Rmd")
```